### PR TITLE
Added a new function 'handleProxyRequest()' and several JavaScript methods in the proxy-handler.js file

### DIFF
--- a/Domain_Blocker/Background/proxy-handler.js
+++ b/Domain_Blocker/Background/proxy-handler.js
@@ -18,9 +18,28 @@ browser.storage.onChanged.addListener(changeData => {
 
 browser.proxy.onRequest.addListener(handleProxyRequest, { urls: ["<all_urls>"] });
 
+// Function that takes a value to check whether the value is in the blockedHosts Array
+function inBlockedHosts(value) {
+    // The indexOf() method returns -1 if the value is not found
+    // If the indexOf() method did not returns -1, the value is found in the inBlockedHosts Array
+    // Reference: https://www.w3schools.com/jsref/jsref_indexof.asp
+    if (blockedHosts.indexOf(value) != -1) {
+        return true; 
+    }
+}
+
 function handleProxyRequest(requestInfo) {
     const url = new URL(requestInfo.url);
-    if (blockedHosts.indexOf(url.hostname) != -1) {
+
+    // split() method to split the url into an array of substrings
+    // split to smaller pieces, separated by "."
+    let splitUrl = url.hostname.split(".");
+    // smaller pieces as value into the inBlockedHosts function using some() method
+    // some() method checks if splitUrl array elements pass the inBlockedHosts function
+    let checkSplitUrl = splitUrl.some(inBlockedHosts);
+
+    // if the smaller pieces is also in blockedHosts Array, proxy
+    if (blockedHosts.indexOf(url.hostname) != -1 || checkSplitUrl === true) {
         console.log(`Proxying: ${url.hostname}`);
         return { type: "http", host: "127.0.0.1", port: 65535 };
     }
@@ -31,3 +50,4 @@ function handleProxyRequest(requestInfo) {
 browser.proxy.onError.addListener(error => {
     console.error(`Proxy error: ${error.message}`);
 });
+


### PR DESCRIPTION
The function and methods allows the web extension to block websites better.

Previously, the exact URL is needed to be entered into the "Host to block" to block the exact website.

For example, to block **YouTube**.
In the previous version, "https://www.youtube.com/" is needed to be entered into the "Host to block". However, users can still access other YouTube videos if the link is not "https://www.youtube.com/". Hence, users can access the Youtube video with the link "https://www.youtube.com/watch?v=2PWMiy4RysI".

Based on my testing with the new function and JavaScript methods included, I was able to block most of the YouTube link by just entering "youtube" into the "Host to block". The precise link such as "https://www.youtube.com/watch?v=2PWMiy4RysI" still works if you wish to block certain videos. 

However, more testing is required to ensure it is stable. 

Thank you 😃   

![Blocked_YouTube](https://user-images.githubusercontent.com/103920748/173479560-85c5bd0f-a551-4e43-b246-ab9ab70e5403.png)

